### PR TITLE
refactor: - update year retrieval logic to use "None" instead of "Unknown" - simplify change filtering logic in save_unified_changes_report - optimize track removal process in CSV handling - update pydantic dependency to version 2.11.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "pydantic==2.11.9",              # Core data validation and models
+  "pydantic==2.11.10",             # Core data validation and models
   "python-dotenv>=1.0.0",          # Configuration and environment
   "pyyaml==6.0.3",                 # YAML configuration parsing
   "aiohttp>=3.12.15",              # HTTP client for API requests

--- a/src/domain/tracks/year_retriever.py
+++ b/src/domain/tracks/year_retriever.py
@@ -694,7 +694,7 @@ class YearRetriever:
             album_name=album,
             track_name=str(track.get("name", "")),
             old_year=str(track.get("year") or "None"),
-            new_year=year or "Unknown",
+            new_year=year or "None",
         )
 
     async def _update_tracks_for_album(

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ requires-dist = [
     { name = "coverage", specifier = "==7.10.7" },
     { name = "cryptography", specifier = "==46.0.2" },
     { name = "mypy", specifier = "==1.18.2" },
-    { name = "pydantic", specifier = "==2.11.9" },
+    { name = "pydantic", specifier = "==2.11.10" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = "==1.2.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
@@ -636,7 +636,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.9"
+version = "2.11.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -644,9 +644,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/5d/09a551ba512d7ca404d785072700d3f6727a02f6f3c24ecfd081c7cf0aa8/pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2", size = 788495, upload-time = "2025-09-13T11:26:39.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/54/ecab642b3bed45f7d5f59b38443dcb36ef50f85af192e6ece103dbfe9587/pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423", size = 788494, upload-time = "2025-10-04T10:40:41.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/d3/108f2006987c58e76691d5ae5d200dd3e0f532cb4e5fa3560751c3a1feba/pydantic-2.11.9-py3-none-any.whl", hash = "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2", size = 444855, upload-time = "2025-09-13T11:26:36.909Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl", hash = "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a", size = 444823, upload-time = "2025-10-04T10:40:39.055Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Refactor change-reporting and CSV synchronization routines for simplicity and performance, correct the year retrieval fallback value, and update pydantic to 2.11.10

Bug Fixes:
- Use "None" instead of "Unknown" as the fallback new_year value in change entries

Enhancements:
- Extract change filtration into a dedicated _is_real_change function and simplify change filtering in save_unified_changes_report
- Optimize CSV track removal by using comprehensions for counting and filtering csv_map

Build:
- Bump pydantic dependency to version 2.11.10