### PR TITLE
fix(icloud): safer rename, accurate dry run

### DIFF
--- a/tests/unit/core/test_icloud_cleanup.py
+++ b/tests/unit/core/test_icloud_cleanup.py
@@ -295,7 +295,7 @@ class TestHandleWinnerRename:
         mock_logger.warning.assert_called_once()
 
     def test_dry_run_no_actual_rename(self, tmp_path: Path, mock_logger: MagicMock) -> None:
-        """Test dry run logs but doesn't rename."""
+        """Test dry run logs but doesn't rename, returns 1 to simulate success."""
         base = tmp_path / "test.json"
         winner = tmp_path / "test 2.json"
         winner.write_text("{}")
@@ -310,9 +310,9 @@ class TestHandleWinnerRename:
         )
 
         result = _handle_winner_rename(ctx, mock_logger)
-        assert result == 0
-        assert winner.exists()  # Still exists
-        assert not base.exists()  # Not created
+        assert result == 1  # Returns 1 to simulate successful rename
+        assert winner.exists()  # Still exists (no actual rename)
+        assert not base.exists()  # Not created (no actual rename)
 
     def test_actual_rename(self, tmp_path: Path, mock_logger: MagicMock) -> None:
         """Test actual rename when conditions are met."""


### PR DESCRIPTION
## Summary

Bug fixes for iCloud cleanup module based on code review findings.

### Fixes

1. **Data loss prevention** - Replaced dangerous `unlink + rename` pattern with atomic `rename()` that overwrites target automatically. Added try/except for proper error handling.

2. **Accurate dry run** - Dry run now returns 1 to simulate successful rename, ensuring `_should_skip_conflict` behaves correctly during dry run.

### Review Findings Analysis

| Finding | Valid | Action |
|---------|-------|--------|
| Dry run doesn't simulate rename effect | Partial | Fixed - return 1 |
| Rename failure loses data | **YES** | Fixed - atomic rename |
| Path.match behavior | No | Path.match works correctly |

## Test Plan

- [x] All 35 icloud_cleanup tests pass
- [x] Existing behavior preserved, only safer

## Summary by Sourcery

Improve safety and correctness of iCloud cleanup rename handling and its dry-run behavior.

Bug Fixes:
- Make winner-to-base rename operation atomic and prevent data loss when the destination file already exists.
- Ensure dry-run mode simulates a successful rename by returning a success code without modifying files.

Tests:
- Update iCloud cleanup dry-run test expectations to reflect the new success return code and clarified behavior.