### PR TITLE
fix(ci): disable coverage threshold for integration/e2e tests

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           PYTHONUNBUFFERED: "1"
         run: |
-          uv run pytest tests/integration/ -v --tb=short -m 'not slow'
+          uv run pytest tests/integration/ -v --tb=short -m 'not slow' --no-cov-on-fail --cov-fail-under=0
 
   e2e:
     name: E2E Tests (macOS)
@@ -56,4 +56,4 @@ jobs:
         env:
           PYTHONUNBUFFERED: "1"
         run: |
-          uv run pytest tests/e2e/ -v --tb=short -m 'not slow'
+          uv run pytest tests/e2e/ -v --tb=short -m 'not slow' --no-cov-on-fail --cov-fail-under=0


### PR DESCRIPTION
## Summary
- Override `--cov-fail-under=70` from pyproject.toml for integration/e2e tests
- These tests naturally have lower coverage (~32%) as they test specific integration paths
- Unit tests still enforce 70% coverage threshold

## Test plan
- [ ] Verify integration tests pass in CI

## Summary by Sourcery

Relax coverage enforcement for integration and E2E test workflows in CI to avoid failing on lower coverage for these suites.

CI:
- Disable coverage thresholds for integration tests in the GitHub Actions workflow while still collecting coverage data.
- Disable coverage thresholds for E2E tests in the GitHub Actions workflow while still collecting coverage data.