### PR TITLE
fix(ci): use check-regexp to wait for CI jobs

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -52,10 +52,12 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          check-name: 'Tests'
+          # Use regexp to match both Lint and Tests jobs
+          check-regexp: '^(Lint & Type Check|Tests)$'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
           allowed-conclusions: success
+          running-workflow-name: 'Mutation Testing Pipeline'
 
       - name: Set continue flag
         id: check


### PR DESCRIPTION
## Summary

Fix mutation testing pipeline failing at "Wait for CI" stage.

## Problem

The `wait-on-check-action` was configured to wait for "Tests" job, but
this job doesn't start immediately (it `needs: lint`). The action exits
immediately when the check doesn't exist yet.

## Solution

Use `check-regexp` to match both "Lint & Type Check" (starts immediately)
and "Tests" jobs. This way the action finds at least one check and waits.

## Test plan
- [ ] Mutation pipeline passes "Wait for CI" stage

## Summary by Sourcery

Update the mutation testing workflow to reliably wait for relevant CI jobs before proceeding.

CI:
- Adjust mutation testing workflow to wait on checks matching either the lint/type-check or test jobs using a regular expression.
- Specify the running workflow name for the wait-on-check action to correctly associate checks with the Mutation Testing Pipeline.