### PR TITLE
feat(ci): incremental mutation testing

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -95,7 +95,7 @@ jobs:
           echo "=== Detecting changed files ==="
 
           # Check for force full or schedule trigger
-          if [ "${{ github.event.inputs.force_full }}" = "true" ] || [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "${{ github.event.inputs.force_full || 'false' }}" = "true" ] || [ "${{ github.event_name }}" = "schedule" ]; then
             echo "Full src/ mutation test requested"
             echo "skip=false" >> $GITHUB_OUTPUT
             echo "files=src/" >> $GITHUB_OUTPUT
@@ -166,28 +166,37 @@ jobs:
 
           echo "=== Configuring cosmic-ray (mode: $MODE) ==="
 
-          if [ "$MODE" = "full" ] || [ "$MODE" = "override" ]; then
-            # Single path mode
-            MODULE_PATH="\"$FILES\""
-          else
-            # Incremental: convert file list to TOML array
-            MODULE_PATH=$(echo "$FILES" | sed 's/^/"/;s/$/"/' | paste -sd, -)
-            MODULE_PATH="[$MODULE_PATH]"
-          fi
+          # Use Python for safe TOML generation
+          python3 << PYEOF
+          import json
 
-          cat > cosmic-ray-ci.toml << EOF
-          [cosmic-ray]
-          module-path = $MODULE_PATH
+          files = """$FILES""".strip()
+          mode = "$MODE"
+
+          if mode in ("full", "override"):
+              # Single path mode - cosmic-ray accepts string for directories
+              module_path = f'"{files}"'
+          else:
+              # Incremental: convert file list to JSON array (valid TOML)
+              file_list = [f.strip() for f in files.split('\n') if f.strip()]
+              module_path = json.dumps(file_list)
+
+          config = f'''[cosmic-ray]
+          module-path = {module_path}
           timeout = 30.0
           excluded-modules = []
           test-command = "uv run pytest tests/unit/ -x -q --no-cov --tb=no"
 
           [cosmic-ray.distributor]
           name = "local"
-          EOF
+          '''
 
-          echo "=== Config ==="
-          cat cosmic-ray-ci.toml
+          with open('cosmic-ray-ci.toml', 'w') as f:
+              f.write(config)
+
+          print("=== Config ===")
+          print(config)
+          PYEOF
 
       - name: Initialize & run baseline
         if: steps.changed.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Only mutate files changed in commit instead of entire modules.

**Before:** `src/metrics/` (8 files) → 300+ mutations → 2.5+ hours
**After:** 1-3 changed files → 30-40 mutations → 15-20 minutes

## Changes

- Add git diff detection for changed Python files
- Generate dynamic cosmic-ray config based on changes
- Add `force_full` input for manual full module test
- Weekly schedule tests entire `src/` with 12h timeout
- Skip downstream jobs if no source files changed

## Triggers

| Event | Scope | Timeout |
|-------|-------|---------|
| Push to main | Changed files only | 2h |
| Manual (default) | Changed files | 2h |
| Manual (force_full) | Full src/ | 2h |
| Weekly schedule | Full src/ | 12h |

## Test plan
- [ ] CI passes
- [ ] Manual trigger with incremental mode
- [ ] Manual trigger with force_full mode

## Summary by Sourcery

Introduce incremental mutation testing in CI to run cosmic-ray only on relevant source changes and skip runs when no Python files are modified.

New Features:
- Support incremental mutation testing by detecting changed Python files via git diff and passing them to cosmic-ray.
- Add workflow_dispatch inputs for forcing a full src/ run and for overriding the target module path.
- Expose mutation test mode and skip status as workflow outputs for downstream jobs.

Enhancements:
- Adjust mutation test timeouts to use longer limits for scheduled full runs while keeping shorter timeouts for incremental runs.
- Skip dependency installation, mutation execution, and metrics update when no relevant source files have changed.
- Report the mutation testing mode instead of the raw module path in the metrics payload.

CI:
- Refine the mutation-testing workflow to dynamically configure cosmic-ray based on changed files or explicit overrides and to skip downstream jobs when the run is skipped.