### PR TITLE
fix(tests): add missing AsyncMock for snapshot service methods

### DIFF
--- a/tests/e2e/test_full_pipeline_allure.py
+++ b/tests/e2e/test_full_pipeline_allure.py
@@ -116,10 +116,13 @@ class TestFullApplicationPipelineE2E:
 
         # Library snapshot service mock (required for smart delta fetch)
         mock_deps.library_snapshot_service = MagicMock()
+        mock_deps.library_snapshot_service.is_enabled = MagicMock(return_value=False)
         mock_deps.library_snapshot_service.is_snapshot_valid = AsyncMock(return_value=False)
         mock_deps.library_snapshot_service.get_track_ids_from_snapshot = AsyncMock(return_value=set())
         mock_deps.library_snapshot_service.load_snapshot = AsyncMock(return_value=None)
         mock_deps.library_snapshot_service.save_snapshot = AsyncMock()
+        mock_deps.library_snapshot_service.get_library_mtime = AsyncMock(return_value=None)
+        mock_deps.library_snapshot_service.compute_smart_delta = AsyncMock(return_value=(set(), set(), set()))
 
         return mock_deps
 


### PR DESCRIPTION
## Summary
- Fix E2E tests failing with `TypeError: object MagicMock can't be used in 'await' expression`
- Add missing `AsyncMock` for `library_snapshot_service` methods

## Root Cause
The E2E tests mock `library_snapshot_service` but were missing async mocks for:
- `is_enabled()` - regular method (now properly mocked)
- `get_library_mtime()` - async method (was missing)
- `compute_smart_delta()` - async method (was missing)

When `music_updater.py:556` calls `await snapshot_service.get_library_mtime()`, a regular `MagicMock` can't be awaited.

## Test Plan
- [x] E2E tests pass locally (5/5)
- [ ] CI E2E tests pass
- [ ] Mutation tests pass

## Summary by Sourcery

Tests:
- Add missing mocks for library_snapshot_service, including AsyncMock for async methods and MagicMock for is_enabled(), to prevent await-related TypeErrors in E2E tests.