### PR TITLE
fix(ci): disable coverage in mutmut baseline tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -428,4 +428,6 @@ skips = ["B101", "B311", "B404", "B603"]
 paths_to_mutate = ["src/"]
 tests_dir = ["tests/"]
 max_stack_depth = 8
-pytest_add_cli_args_test_selection = ["-x", "-q", "--tb=no", "--no-cov", "--ignore=tests/integration", "--ignore=tests/e2e"]
+# Disable coverage for all mutmut pytest calls (baseline + mutations)
+pytest_args = ["--no-cov"]
+pytest_add_cli_args_test_selection = ["-x", "-q", "--tb=no", "--ignore=tests/integration", "--ignore=tests/e2e"]


### PR DESCRIPTION
## Summary
- Add `pytest_args = ["--no-cov"]` to mutmut config to disable coverage during mutation testing
- Fixes mutmut baseline test failure caused by `--cov-fail-under=70` in pytest config

## Problem
Mutmut baseline tests were failing with:
```
FAIL Required test coverage of 70% not reached. Total coverage: 0.05%
Failed to run clean test
```

The global pytest `--cov-fail-under=70` was being applied to mutmut's baseline test run, which only runs mutation-related tests with minimal coverage.