### PR TITLE
fix(year): force flag bypasses local checks + proposed year plausibility

### DIFF
--- a/src/core/tracks/year_batch.py
+++ b/src/core/tracks/year_batch.py
@@ -358,8 +358,8 @@ class YearBatchProcessor:
             return
 
         # Determine the year for this album (handles dominant year, cache, and API)
-        # Note: determine_album_year already checks dominant year internally - no need to call separately
-        year = await self.year_determinator.determine_album_year(artist, album, album_tracks)
+        # Note: force=True bypasses dominant year and cache checks, always queries API
+        year = await self.year_determinator.determine_album_year(artist, album, album_tracks, force=force)
 
         if not year:
             self._handle_no_year_found(artist, album, album_tracks)

--- a/tests/unit/core/tracks/test_year_retriever_edge_cases.py
+++ b/tests/unit/core/tracks/test_year_retriever_edge_cases.py
@@ -1003,13 +1003,14 @@ class TestAbsurdYearDetection:
         assert len(mock_pending.marked_albums) == 0
 
     @allure.severity(allure.severity_level.NORMAL)
-    @allure.title("Rule 2: Absurd year WITH existing → continues (handled by Rule 5)")
+    @allure.title("Rule 2: Absurd year WITH existing → plausibility check catches")
     @pytest.mark.asyncio
     async def test_absurd_year_with_existing_continues(self) -> None:
-        """Test that absurd year with existing year continues to dramatic change rule.
+        """Test that absurd year with existing year is caught by plausibility check.
 
         Case: Album with existing year 2005, proposed year 1965
         Expected: Skip Rule 2 (has existing), proceed to Rule 5 (dramatic change)
+        → Plausibility check catches proposed_year < artist_start_year
         """
         mock_pending = MockPendingVerificationService()
         retriever = self.create_retriever_with_absurd_threshold(
@@ -1029,12 +1030,12 @@ class TestAbsurdYearDetection:
             album="Album",
         )
 
-        # Should be caught by Rule 5 (dramatic change: 2005 → 1965 = 40 years)
+        # Should be caught by plausibility check (proposed 1965 is before artist started)
         assert result is None
         assert len(mock_pending.marked_albums) == 1
-        # Reason should be dramatic change, not absurd year
+        # Reason is now implausible_proposed_year (more specific than suspicious_year_change)
         # marked_albums is a tuple: (artist, album, reason, metadata)
-        assert mock_pending.marked_albums[0][2] == "suspicious_year_change"
+        assert mock_pending.marked_albums[0][2] == "implausible_proposed_year"
 
     @allure.severity(allure.severity_level.NORMAL)
     @allure.title("Rule 2: Edge case - year exactly at threshold")


### PR DESCRIPTION
## Summary

Three related fixes for `--force` mode and year plausibility:

1. **`determine_album_year()` force parameter**: Added `force=False` parameter. When `force=True`, skips dominant year check and cache - always queries API. Previously, `--force` only bypassed `should_skip_album()` but `determine_album_year()` still used cached/dominant years.

2. **Proposed year plausibility check**: Extended `_check_year_plausibility()` to validate `proposed_year` (not just `existing_year`) against artist start year. If API returns year before artist started → preserve existing year (safer).

3. **Pass force flag to `year_batch.py`**: Updated `determine_album_year()` call to pass `force=force` parameter through the batch processing chain.

## Changes

- `src/core/tracks/year_determination.py` - Added force parameter, wrapped dominant year/cache checks
- `src/core/tracks/year_batch.py` - Pass force flag to determine_album_year
- `src/core/tracks/year_fallback.py` - Extended plausibility check for proposed year

## Test plan

- [x] All 2594 tests pass
- [x] 89% coverage maintained
- [x] Updated test expectations for new safer behavior

## Summary by Sourcery

Refine album year determination to respect the force flag and make year updates safer when artist start-year data is missing or implausible.

New Features:
- Add a force option to album year determination that bypasses local dominant year and cache checks to always query the API when requested.

Bug Fixes:
- Treat implausible proposed years (before an artist's start year) as unsafe and preserve the existing year instead of applying the API result.
- When artist start-year data is unavailable, stop defaulting to the API year and instead fall through to later rules that may preserve the existing year.
- Ensure batch year processing correctly propagates the force flag into album year determination.

Enhancements:
- Improve logging and test coverage around year plausibility checks and dramatic year-change handling, including more specific verification reasons for implausible proposed years.

Tests:
- Update and extend unit and regression tests to reflect the new plausibility behavior and force-flag propagation.