### PR TITLE
fix(ci): update mutation-testing to wait for new CI job names

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -57,7 +57,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.4.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          check-regexp: '^(Lint & Type Check|Tests)$'
+          check-regexp: '^(Quality|Security|Test|Gate)$'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
           allowed-conclusions: success


### PR DESCRIPTION
## Summary

Fixes Mutation Testing Pipeline failure after CI job rename.

**Problem**: The `wait-on-check-action` was looking for old job names:
- `Lint & Type Check`
- `Tests`

**Solution**: Updated regex to match new parallel CI job names:
- `Quality`
- `Security`  
- `Test`
- `Gate`

## Test plan

- [ ] Mutation Testing Pipeline waits for CI jobs correctly

## Summary by Sourcery

CI:
- Adjust wait-on-check configuration to match the new CI job names used in the main pipeline.