### PR TITLE
fix(ci): configure git identity before gh-pages commit

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -325,6 +325,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: true  # Required for push to gh-pages
 
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Setup gh-pages branch
         run: |
           # Check if gh-pages exists remotely
@@ -435,9 +440,6 @@ jobs:
 
       - name: Commit & push metrics
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
           git add history.json
 
           if git diff --staged --quiet; then


### PR DESCRIPTION
## Summary
- Move git config (user.name, user.email) before `Setup gh-pages branch` step
- Remove duplicate git config from later step

## Problem
Mutation Testing Pipeline failed with exit code 128:
```
fatal: empty ident name (for <runner@...>) not allowed
```

This occurred when trying to create the initial commit for the `gh-pages` branch (which doesn't exist yet). The git identity was configured too late in the workflow.

## Fix
Configure git identity immediately after checkout, before any git operations that require it.

## Test plan
- [ ] Push to main triggers mutation-testing workflow
- [ ] Workflow passes Stage 3 "Update Metrics"
- [ ] gh-pages branch is created successfully

## Summary by Sourcery

Configure the mutation testing workflow to set the Git user identity immediately after checkout and before creating or updating the gh-pages branch.

CI:
- Move Git user.name and user.email configuration to run right after checkout so initial gh-pages commits have a valid identity.
- Remove the now-redundant Git identity configuration from the later metrics commit step in the mutation testing workflow.