### PR TITLE
fix(mutmut): resolve xdist + mutmut config clash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -343,8 +343,12 @@ skips = ["B101", "B311", "B404", "B603"]
 # ─────────────────────────────────────────────────────────────────────────────
 [tool.mutmut]
 paths_to_mutate = ["src/"]
-tests_dir = ["tests/"]
-max_stack_depth = 8
-# Disable coverage plugin entirely for mutmut (--no-cov alone doesn't prevent fail-under check)
-pytest_args = ["-p", "no:pytest_cov"]
+# Clear pytest addopts and disable problematic plugins for mutmut:
+# - override-ini: clears addopts to prevent conflicts with coverage, xdist, html reports
+# - no:pytest_cov: ensures coverage plugin is fully disabled
+# - no:xdist: fixes mutmut 3.4.0 bug where xdist workers crash with
+#   "AttributeError: 'NoneType' object has no attribute 'max_stack_depth'"
+#   (mutmut.config not initialized in xdist worker processes)
+# - no:html: disables pytest-html report generation
+pytest_add_cli_args = ["--override-ini=addopts=", "-p", "no:pytest_cov", "-p", "no:xdist", "-p", "no:html"]
 pytest_add_cli_args_test_selection = ["-x", "-q", "--tb=no", "--ignore=tests/integration", "--ignore=tests/e2e"]


### PR DESCRIPTION
## Summary
- Fix mutmut 3.4.0 crash during stats collection with xdist workers
- Clear pytest addopts to prevent conflicts with coverage/xdist/html plugins
- Use `--override-ini=addopts=` to reset pytest config for mutmut runs

## Root Cause
When mutmut runs pytest with xdist (`-n auto` from addopts), worker processes don't inherit `mutmut.config`, causing `AttributeError: 'NoneType' object has no attribute 'max_stack_depth'` when trampolines call `record_trampoline_hit`.

## Solution
1. Use `--override-ini=addopts=` to clear pytest's default addopts
2. Explicitly disable conflicting plugins: `-p no:pytest_cov`, `-p no:xdist`, `-p no:html`
3. Fixed config key: use `pytest_add_cli_args` (correct) instead of `pytest_args` (wrong key)

## Test plan
- [x] Verified locally: `uv run mutmut run` now collects stats successfully
- [ ] CI mutation-testing workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)