### PR TITLE
fix(mutmut): patch trampoline bug + re-enable xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -343,12 +343,9 @@ skips = ["B101", "B311", "B404", "B603"]
 # ─────────────────────────────────────────────────────────────────────────────
 [tool.mutmut]
 paths_to_mutate = ["src/"]
-# Clear pytest addopts and disable problematic plugins for mutmut:
-# - override-ini: clears addopts to prevent conflicts with coverage, xdist, html reports
-# - no:pytest_cov: ensures coverage plugin is fully disabled
-# - no:xdist: fixes mutmut 3.4.0 bug where xdist workers crash with
-#   "AttributeError: 'NoneType' object has no attribute 'max_stack_depth'"
-#   (mutmut.config not initialized in xdist worker processes)
-# - no:html: disables pytest-html report generation
-pytest_add_cli_args = ["--override-ini=addopts=", "-p", "no:pytest_cov", "-p", "no:xdist", "-p", "no:html"]
+# Clear pytest addopts and re-enable xdist:
+# - override-ini: clears default addopts (prevents coverage/html conflicts)
+# - no:pytest_cov, no:html: disable these plugins
+# - -n auto: re-enable xdist parallelism (cleared by override-ini)
+pytest_add_cli_args = ["--override-ini=addopts=", "-p", "no:pytest_cov", "-p", "no:html", "-n", "auto"]
 pytest_add_cli_args_test_selection = ["-x", "-q", "--tb=no", "--ignore=tests/integration", "--ignore=tests/e2e"]


### PR DESCRIPTION
## Summary

- **Fix mutmut 3.4.0 bug**: xdist workers crash with `AttributeError: 'NoneType' object has no attribute 'max_stack_depth'` because `mutmut.config` is `None` in worker processes
- **Solution**: Monkey-patch `record_trampoline_hit()` in `conftest.py` to skip when config is uninitialized
- **Re-enable xdist**: Remove `-p no:xdist`, add `-n auto` for parallel test execution (~3x faster)

## Root Cause

mutmut 3.4.0 injects "trampolines" into mutated code that call `record_trampoline_hit()`. This function accesses `mutmut.config.max_stack_depth` without null check. When pytest-xdist spawns worker processes, they import the mutated code but don't have `mutmut.config` initialized.

## Changes

| File | Change |
|------|--------|
| `tests/conftest.py` | Add monkey-patch for `record_trampoline_hit()` |
| `pyproject.toml` | Re-enable xdist with `-n auto` |

## Testing

- ✅ Tested locally: stats collection runs without crash
- ✅ xdist parallelism confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix mutmut trampoline crash under pytest-xdist and re-enable parallel mutation testing.

Bug Fixes:
- Prevent mutmut's record_trampoline_hit from crashing when mutmut.config is uninitialized in xdist worker processes.

Enhancements:
- Monkey-patch mutmut's record_trampoline_hit in the test configuration to safely no-op when configuration is missing.
- Re-enable pytest-xdist parallel execution for mutmut runs via updated pytest CLI arguments in pyproject configuration.