### PR TITLE
fix(docs): grid cards CSS for free Material theme

### DIFF
--- a/docs/stylesheets/ayu.css
+++ b/docs/stylesheets/ayu.css
@@ -209,3 +209,84 @@
 [data-md-color-scheme="default"] .md-typeset .admonition {
   border-color: #E8E9EB;
 }
+
+/* ============================================
+   Grid Cards (replaces Insiders-only feature)
+   ============================================ */
+
+/* Grid container */
+.md-typeset .grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 0.8rem;
+  margin: 1em 0;
+}
+
+/* Cards modifier - remove list styling */
+.md-typeset .grid.cards > ul {
+  display: contents;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* Individual card items */
+.md-typeset .grid.cards > ul > li {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 1.2rem;
+  border-radius: 0.3rem;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+/* Card hover effect */
+.md-typeset .grid.cards > ul > li:hover {
+  transform: translateY(-2px);
+}
+
+/* Card icon styling */
+.md-typeset .grid.cards > ul > li > p:first-child {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.4rem;
+}
+
+/* Large icon modifier */
+.md-typeset .grid.cards .lg {
+  font-size: 1.6rem;
+}
+
+/* Middle alignment modifier */
+.md-typeset .grid.cards .middle {
+  vertical-align: middle;
+}
+
+/* Link styling in cards */
+.md-typeset .grid.cards > ul > li a {
+  margin-top: auto;
+}
+
+/* Dark theme card colors (Ayu Mirage) */
+[data-md-color-scheme="slate"] .md-typeset .grid.cards > ul > li {
+  background-color: #272D38;
+  border: 1px solid #3D424D;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .grid.cards > ul > li:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  border-color: #FFCC66;
+}
+
+/* Light theme card colors (Ayu Light) */
+[data-md-color-scheme="default"] .md-typeset .grid.cards > ul > li {
+  background-color: #FFFFFF;
+  border: 1px solid #E8E9EB;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+[data-md-color-scheme="default"] .md-typeset .grid.cards > ul > li:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-color: #FF9940;
+}


### PR DESCRIPTION
## Summary
- Add custom CSS to enable grid cards layout (Insiders-only feature)
- Implement CSS Grid with auto-fit responsive columns
- Add card styling with hover effects for both Ayu themes

## Problem
Grid cards (`<div class="grid cards">`) are an Insiders-only feature in Material for MkDocs. The free version doesn't include the necessary CSS, causing cards to display as a single column.

## Solution
Added custom CSS in `ayu.css` that replicates the grid layout:
- `display: grid` with `auto-fit` columns
- Card background, borders, and shadows
- Hover effects (elevation + border color change)
- Support for both Ayu Mirage (dark) and Ayu Light themes

## Summary by Sourcery

Add custom CSS to implement responsive grid card layouts in the free Material for MkDocs Ayu theme.

New Features:
- Introduce a grid-based cards layout for documentation pages using the Ayu theme, matching the Insiders-only grid cards behavior.

Enhancements:
- Style grid cards with icons, spacing, and link placement for consistent visual presentation across cards.
- Add hover elevation and border color accents tailored for both Ayu Mirage (dark) and Ayu Light themes.