### PR TITLE
fix(ci): add env var fallbacks for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,9 @@ jobs:
 
       - name: Run tests
         env:
-          DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
-          CONTACT_EMAIL: ${{ secrets.CONTACT_EMAIL }}
-          LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+          DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN || 'ci_dummy_token' }}
+          CONTACT_EMAIL: ${{ secrets.CONTACT_EMAIL || 'ci@example.com' }}
+          LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY || 'ci_dummy_key' }}
         run: |
           uv run pytest tests/ -v \
             --cov=src \


### PR DESCRIPTION
── Summary ─────────────────────────────────

Fix all 5 dependabot PRs failing on Test job due to missing
repository secrets. GitHub security policy prevents dependabot
from accessing `secrets.*` — causing `load_config()` to throw
`ValueError: Missing required environment variables`.

── Changes ─────────────────────────────────

| Type | File                          | Description                          |
|------|-------------------------------|--------------------------------------|
| Fix  | `.github/workflows/ci.yml:118`| Fallback values for `DISCOGS_TOKEN`  |
| Fix  | `.github/workflows/ci.yml:119`| Fallback values for `CONTACT_EMAIL`  |
| Fix  | `.github/workflows/ci.yml:120`| Fallback values for `LASTFM_API_KEY` |

── Validation ──────────────────────────────

```bash
# Integration test passes locally
uv run pytest tests/integration/services/test_dependency_container_integration.py -v  # 1 passed

# Full test suite
uv run pytest  # 3011 passed
```

── Notes ───────────────────────────────────

The `||` operator provides dummy values only when secrets are
empty (dependabot context). Real secrets still take priority
for non-dependabot runs. API integration tests self-skip via
their own `@pytest.mark.skipif` when real tokens are absent.

After merging, all 5 dependabot PRs (#190-#194) need rebase
on main to pick up this fix.

## Summary by Sourcery

CI:
- Add dummy fallback values for DISCOGS_TOKEN, CONTACT_EMAIL, and LASTFM_API_KEY in the CI workflow so tests still run when secrets are unavailable.