### PR TITLE
fix(ci): unblock dependabot PRs with test-scoped env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,9 @@ jobs:
 
       - name: Run tests
         env:
-          DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN || 'ci_dummy_token' }}
-          CONTACT_EMAIL: ${{ secrets.CONTACT_EMAIL || 'ci@example.com' }}
-          LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY || 'ci_dummy_key' }}
+          DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
+          CONTACT_EMAIL: ${{ secrets.CONTACT_EMAIL }}
+          LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
         run: |
           uv run pytest tests/ -v \
             --cov=src \

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned hypothesis==6.151.4 for reproducible test runs
 - Applied ruff format to all new test files
 
+### Fixed
+- Dependabot PRs failing CI due to missing env vars in `load_config()` validation
+
 ## [3.0.0] - 2026-01-12
 
 ### Added

--- a/tests/integration/services/test_dependency_container_integration.py
+++ b/tests/integration/services/test_dependency_container_integration.py
@@ -28,6 +28,18 @@ import yaml
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 
 
+@pytest.fixture(autouse=True)
+def _set_required_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure load_config() env var validation passes in CI.
+
+    load_config() validates DISCOGS_TOKEN and CONTACT_EMAIL before
+    reading the config file. In dependabot CI runs these env vars
+    are absent (secrets not exposed), causing ValueError.
+    """
+    monkeypatch.setenv("DISCOGS_TOKEN", "test_token_for_ci")
+    monkeypatch.setenv("CONTACT_EMAIL", "ci@example.com")
+
+
 def _get_complete_config_data(
     *,
     applescript_retry: dict | None = None,


### PR DESCRIPTION
── Summary ─────────────────────────────────

Fix dependabot PRs failing on `test_initialize_creates_all_services`
due to missing `DISCOGS_TOKEN`/`CONTACT_EMAIL` env vars.

Supersedes approach from #196: CI-level fallback values caused
real API integration tests to **run** instead of **skip**, producing
flaky failures (MusicBrainz returned different year for classic rock album).

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Fix  | `.github/workflows/ci.yml:118` | Revert to original secrets (no fallbacks) |
| Fix  | `tests/integration/services/test_dependency_container_integration.py:32` | `autouse` monkeypatch fixture sets env vars per-test |

── Validation ──────────────────────────────

```bash
uv run pytest tests/integration/services/test_dependency_container_integration.py -v  # 25 passed
uv run ruff check tests/ && uv run ruff format --check tests/  # clean
```

── Notes ───────────────────────────────────

Two separate env var checks were conflicting:
1. `core_config.py:validate_required_env_vars()` — needs non-empty env vars
2. `test_external_api_real.py:_check_required_secrets()` — needs **absent** env vars to skip

The monkeypatch approach satisfies (1) at test scope without
affecting (2), because monkeypatch is scoped to each test function.

After merge, `@dependabot rebase` on PRs #190-#194 will pick up
the corrected ci.yml + test fixture.

## Summary by Sourcery

Ensure CI tests pass for Dependabot PRs by scoping required environment variables to tests instead of using CI-level fallbacks.

Bug Fixes:
- Prevent integration tests from failing in Dependabot runs by providing required env vars via an autouse test fixture rather than relying on CI secrets fallbacks.

Documentation:
- Document the fix for Dependabot CI failures due to missing env vars in the changelog.