### PR TITLE
fix: type errors, pyjwt CVE, config tuning

### DIFF
--- a/my-config.yaml
+++ b/my-config.yaml
@@ -38,7 +38,9 @@ retry_delay_seconds: 1 # Base delay between retries
 # In-memory cache settings (used by CacheService for temporary data like fetched tracks)
 cache_ttl_seconds: 1800 # Default lifetime for in-memory cache items (30 min)
 # Incremental update settings
-incremental_interval_minutes: 1 # Interval for incremental updates (1 minute)
+# Slightly below the launchctl ThrottleInterval (900s = 15min) to avoid
+# sub-second drift causing the Python gate to reject a launchctl tick.
+incremental_interval_minutes: 14 # Interval for incremental updates (14 minutes)
 # -----------------------------------------------------------------------
 # 3. FEATURE TOGGLES AND SETTINGS
 # -----------------------------------------------------------------------
@@ -135,9 +137,12 @@ logging:
   csv_output_file: csv/track_list.csv
   changes_report_file: csv/changes_report.csv
   dry_run_report_file: reports/dry_run_report.html
-  last_incremental_run_file: last_incremental_run.log
+  # State files must live on local APFS (not iCloud Drive) to avoid EDEADLK
+  # from iCloud file provider locking during active write. Absolute paths
+  # override logs_base_dir thanks to pathlib's join-reset-on-absolute behavior.
+  last_incremental_run_file: /Users/cloud/Library/Application Support/GenreUpdater/state/last_incremental_run.log
   pending_verification_file: csv/pending_year_verification.csv
-  last_db_verify_log: main/last_db_verify.log
+  last_db_verify_log: /Users/cloud/Library/Application Support/GenreUpdater/state/last_db_verify.log
 
   # Log levels configuration
   levels:

--- a/scripts/create_issue.py
+++ b/scripts/create_issue.py
@@ -408,9 +408,9 @@ def main() -> int:
         return 0
 
     # Connect to GitHub
-    repo: Repository | None = None
     if args.dry_run:
         print("\n[DRY RUN MODE - No issues will be created]\n")
+        repo = None
     else:
         github_client = Github(auth=Auth.Token(token))  # type: ignore[arg-type]
         repo = github_client.get_repo(args.repo)

--- a/src/app/app_config.py
+++ b/src/app/app_config.py
@@ -7,16 +7,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import yaml
+from dotenv import load_dotenv
 
 from core.core_config import load_config as load_yaml_config
 
 if TYPE_CHECKING:
     from core.models.track_models import AppConfig
-
-try:
-    from dotenv import load_dotenv
-except ImportError:
-    load_dotenv = None  # type: ignore[assignment]
 
 # User config takes precedence over template (my-config.yaml is gitignored)
 DEFAULT_CONFIG_FILES: list[str] = ["my-config.yaml", "config.yaml"]
@@ -27,19 +23,17 @@ class Config:
 
     Handles config file discovery (env var, defaults) and delegates
     YAML loading + Pydantic validation to ``core.core_config.load_config``.
+
+    Args:
+        config_path: Path to the configuration file (use default if None)
+
+    Raises:
+        FileNotFoundError: If no configuration file is found.
     """
 
     def __init__(self, config_path: str | None = None) -> None:
-        """Initialize configuration.
-
-        Args:
-            config_path: Path to the configuration file (use default if None)
-
-        """
         if config_path is None:
-            # Load .env file if not already loaded
-            if load_dotenv is not None:
-                load_dotenv()
+            load_dotenv()
 
             # Try environment variable first, then try each default config file
             config_path = os.getenv("CONFIG_PATH")
@@ -56,8 +50,8 @@ class Config:
                 )
                 raise FileNotFoundError(msg)
 
-        # config_path is guaranteed to be not None at this point
-        self.config_path = config_path
+        # config_path is guaranteed to be str at this point
+        self.config_path: str = config_path
         self._resolved_path: str | None = None
         self._app_config: AppConfig | None = None
 
@@ -76,18 +70,21 @@ class Config:
         Returns:
             Validated AppConfig Pydantic model.
 
+        Raises:
+            RuntimeError: If the configuration file cannot be loaded or parsed.
         """
-        if self._app_config is None:
-            load_path = Path(os.path.expandvars(self.config_path)).expanduser()
-            try:
-                app_config = load_yaml_config(str(load_path))
-            except (OSError, ValueError, yaml.YAMLError, RuntimeError) as e:
-                msg = f"Failed to load configuration from '{load_path}': {e}"
-                raise RuntimeError(msg) from e
-            self._app_config = app_config
-            self._resolved_path = self._resolve_config_path()
+        if self._app_config is not None:
+            return self._app_config
 
-        return self._app_config
+        load_path = Path(os.path.expandvars(self.config_path)).expanduser()
+        try:
+            app_config = load_yaml_config(str(load_path))
+        except (OSError, ValueError, yaml.YAMLError, RuntimeError) as e:
+            msg = f"Failed to load configuration from '{load_path}': {e}"
+            raise RuntimeError(msg) from e
+        self._app_config = app_config
+        self._resolved_path = self._resolve_config_path()
+        return app_config
 
     @property
     def resolved_path(self) -> str:

--- a/src/services/cache/orchestrator.py
+++ b/src/services/cache/orchestrator.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 from core.logger import LogFormat
 from core.models.protocols import CacheableKey, CacheableValue, CacheServiceProtocol
@@ -36,15 +36,14 @@ T = TypeVar("T")
 
 
 class CacheOrchestrator(CacheServiceProtocol):
-    """Orchestrates multiple specialized cache services with unified interface."""
+    """Orchestrates multiple specialized cache services with unified interface.
+
+    Args:
+        config: Typed application configuration
+        logger: Optional logger instance
+    """
 
     def __init__(self, config: AppConfig, logger: logging.Logger | None = None) -> None:
-        """Initialize CacheOrchestrator with configuration.
-
-        Args:
-            config: Typed application configuration
-            logger: Optional logger instance
-        """
         self.config = config
         self.logger = logger or logging.getLogger(__name__)
         # Initialize configuration manager later when needed
@@ -75,7 +74,7 @@ class CacheOrchestrator(CacheServiceProtocol):
         results = await asyncio.gather(*(task for _, task in service_tasks), return_exceptions=True)
 
         failed_services: list[str] = []
-        for (service_name, _), result in zip(service_tasks, results, strict=False):
+        for (service_name, _), result in zip(service_tasks, results, strict=True):
             if isinstance(result, Exception):
                 self.logger.error("Failed to initialize %s: %s", LogFormat.entity(service_name), result, exc_info=result)
                 failed_services.append(service_name)
@@ -114,7 +113,28 @@ class CacheOrchestrator(CacheServiceProtocol):
 
     # Generic Cache API
 
-    async def get_async(  # type: ignore[override]  # Protocol uses @overload with Literal["ALL"]; concrete impl uses a single unified signature
+    @overload
+    async def get_async(
+        self,
+        key_data: Literal["ALL"],
+        compute_func: None = None,
+    ) -> list[TrackDict]: ...
+
+    @overload
+    async def get_async(
+        self,
+        key_data: str,
+        compute_func: None = None,
+    ) -> list[TrackDict] | None: ...
+
+    @overload
+    async def get_async(
+        self,
+        key_data: CacheableKey,
+        compute_func: Callable[[], asyncio.Future[CacheableValue]] | None = None,
+    ) -> CacheableValue: ...
+
+    async def get_async(
         self,
         key_data: CacheableKey,
         compute_func: Callable[[], asyncio.Future[CacheableValue]] | None = None,
@@ -217,7 +237,7 @@ class CacheOrchestrator(CacheServiceProtocol):
 
         results = await asyncio.gather(*(task for _, task in save_tasks), return_exceptions=True)
 
-        for (service_name, _), result in zip(save_tasks, results, strict=False):
+        for (service_name, _), result in zip(save_tasks, results, strict=True):
             if isinstance(result, Exception):
                 self.logger.error("Failed to save %s to disk: %s", LogFormat.entity(service_name), result, exc_info=result)
 

--- a/uv.lock
+++ b/uv.lock
@@ -715,6 +715,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -1758,11 +1759,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Fix 2 ty type checker errors blocking CI (load_dotenv assignment, CacheOrchestrator LSP violation)
- Upgrade pyjwt 2.11.0 → 2.12.1 to fix CVE-2026-32597 (HIGH)
- Fix IDE type narrowing warnings in app_config.py and create_issue.py
- Align incremental interval to 14min (below launchctl 15min throttle)
- Move state files to local APFS to avoid iCloud EDEADLK deadlocks

## Test plan

- [x] ty check passes (0 errors)
- [x] ruff check + format passes
- [x] pydoclint passes
- [x] pytest: 3195 passed, 89.36% coverage
- [ ] CI passes on this PR

## Summary by Sourcery

Resolve type-checking and configuration issues, tighten cache orchestration typing, and adjust local configuration defaults for safer scheduling and state storage.

Bug Fixes:
- Fix type checker errors in configuration loading and cache orchestration to unblock CI.
- Correct potential uninitialized GitHub repository reference when running the issue creation script in dry-run mode.

Enhancements:
- Simplify dotenv loading and configuration file handling in the app configuration module, with clearer typing and error reporting.
- Refine CacheOrchestrator async cache API with precise overloads and stricter result alignment during initialization and save operations.
- Adjust default incremental update interval and relocate log state files to local storage in the sample configuration for more reliable scheduling and I/O behavior.

Build:
- Update Python dependency lockfile, including upgrading pyjwt to a version that addresses a high-severity CVE.

Documentation:
- Improve docstrings and inline comments for configuration and cache orchestration to better describe behavior and failure modes.